### PR TITLE
Remove createJSModules override - RN 0.47 compatibility

### DIFF
--- a/android/src/main/java/com/opensettings/OpenSettingsPackage.java
+++ b/android/src/main/java/com/opensettings/OpenSettingsPackage.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 public class OpenSettingsPackage implements ReactPackage {
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
[Breaking change](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) from React Native 0.47 