### PR TITLE
Update RNOpenSettings.m

### DIFF
--- a/RNOpenSettings.m
+++ b/RNOpenSettings.m
@@ -7,6 +7,7 @@
 //
 
 #import "RNOpenSettings.h"
+#import <UIKit/UIKit.h>
 
 @implementation RNOpenSettings
 


### PR DESCRIPTION
Running MacOS 10.15 beta and Xcode 10.

When trying to build an app that uses this library as a dependency, the build fails saying `UIApplication` is undefined. This fixes that by adding the right import